### PR TITLE
Make the pull command works on any remote or branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ My personnal toolbox
     > node github/clone_repositories.js --token <TOKEN> --destination <PATH>
   ```
 
-- Pull all repositories from origin/default-branch (e.g. origin/master, origin/main)
+- Pull all repositories from origin/<DEFAULT_BRANCH> (e.g. origin/master, origin/main)
 
   ```
     > node github/pull_repositories.js --target <PATH>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ My personnal toolbox
     > node github/clone_repositories.js --token <TOKEN> --destination <PATH>
   ```
 
-- Pull all repositories from origin/master
+- Pull all repositories from origin/default-branch (e.g. origin/master, origin/main)
+
   ```
     > node github/pull_repositories.js --target <PATH>
   ```

--- a/github/git/pull.js
+++ b/github/git/pull.js
@@ -1,37 +1,53 @@
 const path = require('path');
 const simpleGit = require('simple-git');
 
-const ORIGIN = 'origin';
-const MASTER = 'master';
-const MAIN = 'main';
-
 const git = simpleGit();
+
+const DEFAULT_ORIGIN = 'origin';
+// By default, GitHub names the default branch main in any new repository.
+const DEFAULT_BRANCH = 'main';
+
+const findDefaultOriginAndBranch = async () => {
+  // Answers in the form of `origin/branch`
+  const gitSymbolicCmd = await git.raw(
+    'symbolic-ref',
+    '--short',
+    'refs/remotes/origin/HEAD',
+  );
+  const originAndBranch = gitSymbolicCmd.trim().split('/');
+
+  return {
+    origin: originAndBranch[0] ?? DEFAULT_ORIGIN,
+    branch: originAndBranch[1] ?? DEFAULT_BRANCH,
+  };
+};
 
 async function pull({ target, repository }) {
   const repositoryPath = path.resolve(target, repository);
 
   await git.cwd(repositoryPath).fetch();
-
   const status = await git.cwd(repositoryPath).status();
   const isClean = status.isClean();
-  const isMasterCheckedOut = status.current === MASTER || MAIN;
+
+  const { origin, branch } = await findDefaultOriginAndBranch();
 
   if (!isClean) {
     throw new Error(`The copy is not clean: ${repositoryPath}`);
   }
 
-  if (!isMasterCheckedOut) {
-    throw new Error(`The repo is not currently on master: ${repositoryPath}`);
-  }
-
-  if (status.ahead !== 0) {
+  const isDefaultBranchCheckedOut = status.current === branch;
+  if (!isDefaultBranchCheckedOut) {
     throw new Error(
-      `The branch is ahead compared to remote: ${repositoryPath}`,
+      `The repo is currently not on the default branch (${branch}): ${repositoryPath}`,
     );
   }
 
+  if (status.ahead !== 0) {
+    throw new Error(`The branch is ahead of its remote: ${repositoryPath}`);
+  }
+
   if (status.behind > 0) {
-    await git.cwd(repositoryPath).pull(ORIGIN, MASTER, { '--no-rebase': null });
+    await git.cwd(repositoryPath).pull(origin, branch, { '--no-rebase': null });
   }
 }
 

--- a/github/git/pull.js
+++ b/github/git/pull.js
@@ -14,12 +14,13 @@ const findDefaultOriginAndBranch = async () => {
     '--short',
     'refs/remotes/origin/HEAD',
   );
-  const originAndBranch = gitSymbolicCmd.trim().split('/');
 
-  return {
-    origin: originAndBranch[0] ?? DEFAULT_ORIGIN,
-    branch: originAndBranch[1] ?? DEFAULT_BRANCH,
-  };
+  const [
+    origin = DEFAULT_ORIGIN,
+    branch = DEFAULT_BRANCH,
+  ] = gitSymbolicCmd.trim().split('/');
+
+  return { origin, branch };
 };
 
 async function pull({ target, repository }) {

--- a/github/pull_repositories.js
+++ b/github/pull_repositories.js
@@ -64,7 +64,7 @@ if (require.main === module) {
   // Code section that will run only if current file is the entry point.
   program
     .description(
-      'Script to update all repositories from origin/master if master is the current branch',
+      'Script to update all repositories from origin/<default_branch> when default_branch is the one currently checked',
     )
     .requiredOption(
       '-t, --target <target>',


### PR DESCRIPTION
Hi there 👋. First, thank you very much for this handy tool 🙇.

# Context

When updating a repository that have `main` as the default branch, I have encountered this issue:

```
warn: - some-repo: (fatal: couldn't find remote ref master)
```

Indeed, the [master branch](https://github.com/maximejimenez/toolbox/blob/ca89c5045c58658c32a163e4e3230de6b6b863bd/github/git/pull.js#L34) is referenced in a few places and this one is particularly important since it is hardcoded for the pull command 😃.

# Proposal

Thanks to this handy command:

```
git symbolic-ref --short refs/remotes/origin/HEAD
```

We can retrieve the default branch and its remote in this format: `origin/master`, `origin/main`, etc. I kept a fallback on `origin` for the remote name and `main` for the default branch since it is now the prefered name for new GitHub's repositories.
